### PR TITLE
Fix missing repo and regex

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,5 +1,5 @@
 export const isRepoUrl = (url) => {
-  const githubRepo = /^https?:\/\/(www\.)?github\.com\/[a-zA-z0-9-.]+\/[a-zA-z0-9-.]+\/?/;
+  const githubRepo = /^https?:\/\/(www\.)?github\.com\/[a-zA-z0-9-.]+\/[a-zA-z0-9-.]+\/?($|tree\/[a-zA-z0-9-.]+\/?)([a-zA-z0-9-./]+)?/;
 
   return githubRepo.test(url);
 };

--- a/pages/index.js
+++ b/pages/index.js
@@ -59,7 +59,7 @@ export default class Index extends React.Component {
 
   render() {
     const {query} = this.props.url;
-    const {repoName, repoURL, repoBranch, branchDirectory} = parseRepoURL(query.repo);
+    const {repoName, repoURL, repoBranch, branchDirectory} = query.repo ? parseRepoURL(query.repo) : {};
     const {deploying, deployedUrl, _errors} = this.state;
 
     return (


### PR DESCRIPTION
This is pretty critical:

This fixes an issue when the `repo` is not provided in the `params`. Without this fix the homepage is going to throw a `500` error. 😭 

Also, I improved the regex for the `repo` URL to ensure that you're passing either a root, a tree, or a tree and directory:

Good:
https://github.com/zpnk/deploy.now
https://github.com/zpnk/deploy.now/
https://github.com/zpnk/deploy.now/tree/master
https://github.com/zpnk/deploy.now/tree/master/
https://github.com/zeit/next.js/tree/master/examples/basic-css

Bad:
https://github.com/zeit/next.js/examples/basic-css

Please give this a once over to make sure I didn't make any mistakes. 🙏 