### PR TITLE
chore(form): remove default three env vars

### DIFF
--- a/components/Form.js
+++ b/components/Form.js
@@ -25,23 +25,15 @@ export default class Form extends React.Component {
   }
 
   buildEnvs = (initial) => {
-    let defaults = [
-      {key: '', value: ''},
-      {key: '', value: ''},
-      {key: '', value: ''}
-    ];
-
-    if (!initial) return defaults;
+    if (!initial) return [];
 
     if (initial.constructor === String)
-      defaults = [{key: initial, value: '', required: true}];
+      return [{key: initial, value: '', required: true}];
 
     if (initial.constructor === Array)
-      defaults = initial.map((env) => {
+      return initial.map((env) => {
         return {key: env, value: '', required: true};
       });
-
-    return defaults;
   }
 
   handleChange = ({target}) => {


### PR DESCRIPTION
These were annoying to remove when testing it out, since they are required as soon as they are visible.

This allows `buildEnvs` to be slightly more simple

Fixes #16

I had a hard time getting it to run with npm/yarn install issues, so you better try out this branch locally too 😄 